### PR TITLE
fix: 기기 너비에 따른 폰트크기 조절 및 단어단위로 줄바꿈 하도록 수정

### DIFF
--- a/src/pages/Omedetou.page.tsx
+++ b/src/pages/Omedetou.page.tsx
@@ -51,7 +51,7 @@ const OmedetouText = styled.span`
   word-break: keep-all;
 
   color: white;
-  font-size: 5vw;
+  font-size: 5rem;
   text-shadow: 2px 2px 2px black;
 
   @media screen and (max-width: 768px) {

--- a/src/pages/Omedetou.page.tsx
+++ b/src/pages/Omedetou.page.tsx
@@ -13,7 +13,7 @@ export const Omedetou = ({ name }: { name: string }) => {
     <Container>
       <Confetti width={windowSize.width} height={windowSize.height} />
 
-      <MuteButton onClick={() => setMuted(muteState => !muteState)}>
+      <MuteButton onClick={() => setMuted((muteState) => !muteState)}>
         <i className={`xi-volume-${muted ? "off" : "up"}`}></i>
       </MuteButton>
 
@@ -47,10 +47,24 @@ const OmedetouText = styled.span`
   bottom: 4rem;
   left: 50%;
   transform: translateX(-50%);
+  text-align: center;
+  word-break: keep-all;
 
   color: white;
-  font-size: 5rem;
+  font-size: 5vw;
   text-shadow: 2px 2px 2px black;
+
+  @media screen and (max-width: 768px) {
+    font-size: 3rem;
+  }
+
+  @media screen and (max-width: 480px) {
+    font-size: 2rem;
+  }
+
+  @media screen and (max-width: 320px) {
+    font-size: 1.5rem;
+  }
 `;
 
 const Video = styled.video`


### PR DESCRIPTION
## 문제 상황

모바일에서 글자가 넘치는 문제가 있었음

## 💡 변경 사항 (Changes)
- 기기 너비에 따른 반응형 폰트 크기 설정
- 텍스트 줄바꿈 속성 추가 (word-break: keep-all)
- 폰트 가운데 정렬

## 📱 상세 내용 (Details)
### 폰트 크기 최적화
- Desktop (> 768px): 5rem
- Tablet (≤ 768px): 3rem
- Mobile (≤ 480px): 2rem
- Small Mobile (≤ 320px): 1.5rem

### 텍스트 처리
- `word-break: keep-all` 속성 추가로 한글 텍스트가 단어 단위로 줄바꿈되도록 개선

## 📸 스크린샷 (Screenshots)

해상도: 800 x 624
![localhost_3000_omedetou_name=%EC%95%88%EB%85%95](https://github.com/user-attachments/assets/3b1774d2-1edb-41e3-ab6d-4ca07261a342)

해상도: 500 x 624

![localhost_3000_omedetou_name=%EC%95%88%EB%85%95 (1)](https://github.com/user-attachments/assets/91a8ad83-a141-4d6e-8487-b8587140ae14)

해상도: 400 x 624

![localhost_3000_omedetou_name=%EC%95%88%EB%85%95 (3)](https://github.com/user-attachments/assets/f0163918-c7c5-4a6d-95ec-4357822e0df1)


해상도: 300 x 624

![localhost_3000_omedetou_name=%EC%95%88%EB%85%95 (2)](https://github.com/user-attachments/assets/3864ae68-ed46-4ae0-80f5-1364a86140d8)
